### PR TITLE
BTO configurator UI redesign, developer docs, and bto-calculator app

### DIFF
--- a/app/routes/bto.$handle.jsx
+++ b/app/routes/bto.$handle.jsx
@@ -12,7 +12,7 @@
 // ============================================================
 
 import {useLoaderData} from 'react-router';
-import {CartForm} from '@shopify/hydrogen';
+import {CartForm, Image} from '@shopify/hydrogen';
 import {useState, useMemo, useCallback} from 'react';
 import '../styles/bto.css';
 
@@ -81,6 +81,7 @@ export async function loader({params, context}) {
     peripheralConfig,
     serviceConfig,
     variantId: product?.variants?.nodes?.[0]?.id || null,
+    productImage: product?.featuredImage || null,
     availabilityMap,
   };
 }
@@ -88,7 +89,7 @@ export async function loader({params, context}) {
 
 export default function BTOConfigurator() {
   const data = useLoaderData();
-  const {productName, basePrice, hardwareConfig, peripheralConfig, serviceConfig, variantId, availabilityMap} = data;
+  const {productName, basePrice, hardwareConfig, peripheralConfig, serviceConfig, variantId, productImage, availabilityMap} = data;
   const [outOfStockDialog, setOutOfStockDialog] = useState(null);
   const allSections = [
     ...hardwareConfig.sections,
@@ -242,14 +243,6 @@ export default function BTOConfigurator() {
     });
   };
 
-  const tabs = [
-    {key: 'hardware', label: 'ハードウェア', config: hardwareConfig},
-    {key: 'peripheral', label: '周辺機器', config: peripheralConfig},
-    {key: 'service', label: 'ソフト・サービス', config: serviceConfig},
-  ];
-
-  const activeConfig = tabs.find((t) => t.key === activeTab)?.config;
-
   // カスタマイズ件数
   const customCount = useMemo(() => {
     let count = 0;
@@ -265,38 +258,51 @@ export default function BTOConfigurator() {
     return count;
   }, [selections, allSections]);
 
+  const sectionGroups = [
+    {label: 'ハードウェア', sections: hardwareConfig.sections},
+    {label: '周辺機器', sections: peripheralConfig.sections},
+    {label: 'ソフト・サービス', sections: serviceConfig.sections},
+  ];
+
   return (
     <div className="bto-page">
+      {/* Two-column header: image + product info */}
       <div className="bto-header">
-        <h1>{productName}</h1>
-        <p className="bto-sku">SKU: {data.sku}</p>
+        {productImage && (
+          <div className="bto-header-image">
+            <Image data={productImage} sizes="360px" alt={productName} />
+          </div>
+        )}
+        <div className="bto-header-info">
+          <h1 className="bto-header-title">{productName}</h1>
+          <p className="bto-sku">#{data.sku}</p>
+          <div className="bto-header-price">
+            <span className="bto-header-price-label">販売価格:</span>
+            <span className="bto-header-price-value">&yen;{totalPrice.toLocaleString()}</span>
+            <span className="bto-header-price-tax">（税別 &yen;{Math.round(totalPrice / 1.1).toLocaleString()}）</span>
+          </div>
+        </div>
       </div>
 
       <div className="bto-layout">
         <div className="bto-main">
-          <div className="bto-tabs">
-            {tabs.map((tab) => (
-              <button
-                key={tab.key}
-                className={'bto-tab ' + (activeTab === tab.key ? 'active' : '')}
-                onClick={() => setActiveTab(tab.key)}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="bto-categories">
-            {activeConfig?.sections.map((section) => (
-              <BTOCategory
-                key={section.slug}
-                section={section}
-                selectedIndex={selections[section.slug]}
-                onSingleSelect={(idx) => handleSingleSelect(section.slug, idx)}
-                onMultiSelect={(idx) => handleMultiSelect(section.slug, idx)}
-              />
-            ))}
-          </div>
+          {/* All sections in one scrollable list, grouped with headings */}
+          {sectionGroups.map((group) => (
+            <div key={group.label} className="bto-section-group">
+              <h2 className="bto-section-group-label">{group.label}</h2>
+              <div className="bto-categories">
+                {group.sections.map((section) => (
+                  <BTOCategory
+                    key={section.slug}
+                    section={section}
+                    selectedIndex={selections[section.slug]}
+                    onSingleSelect={(idx) => handleSingleSelect(section.slug, idx)}
+                    onMultiSelect={(idx) => handleMultiSelect(section.slug, idx)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
 
         <div className="bto-sidebar">
@@ -311,26 +317,6 @@ export default function BTOConfigurator() {
             {totalPrice !== basePrice && (
               <div className="bto-price-diff">
                 カスタマイズ ({customCount}件): +&yen;{(totalPrice - basePrice).toLocaleString()}
-              </div>
-            )}
-            {outOfStockDialog && (
-              <div className="bto-oos-overlay" onClick={() => setOutOfStockDialog(null)}>
-                <div className="bto-oos-dialog" onClick={(e) => e.stopPropagation()}>
-                  <div className="bto-oos-dialog-header">
-                    <h3>在庫切れの部品があります</h3>
-                    <p>以下の部品は現在在庫がないため、カートに追加できません:</p>
-                  </div>
-                  <ul>
-                    {outOfStockDialog.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                  <div className="bto-oos-dialog-footer">
-                    <button className="bto-oos-close" onClick={() => setOutOfStockDialog(null)}>
-                      閉じる
-                    </button>
-                  </div>
-                </div>
               </div>
             )}
             {variantId ? (
@@ -362,6 +348,27 @@ export default function BTOConfigurator() {
           </div>
         </div>
       </div>
+
+      {outOfStockDialog && (
+        <div className="bto-oos-overlay" onClick={() => setOutOfStockDialog(null)}>
+          <div className="bto-oos-dialog" onClick={(e) => e.stopPropagation()}>
+            <div className="bto-oos-dialog-header">
+              <h3>在庫切れの部品があります</h3>
+              <p>以下の部品は現在在庫がないため、カートに追加できません:</p>
+            </div>
+            <ul>
+              {outOfStockDialog.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <div className="bto-oos-dialog-footer">
+              <button className="bto-oos-close" onClick={() => setOutOfStockDialog(null)}>
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -481,6 +488,12 @@ const PRODUCT_VARIANT_QUERY = `#graphql
   query BTOProductVariant($handle: String!) {
     product(handle: $handle) {
       id
+      featuredImage {
+        url
+        altText
+        width
+        height
+      }
       variants(first: 1) {
         nodes {
           id

--- a/app/styles/bto.css
+++ b/app/styles/bto.css
@@ -1,182 +1,257 @@
 /* ============================================================
-   BTO Configurator Styles
+   BTO Configurator — Mouse Computer inspired layout
    ============================================================ */
 
 .bto-page {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem 1rem;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 1.5rem 1rem 3rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic', Meiryo, sans-serif;
+  color: #333;
+  background: #fff;
 }
 
+/* ── Two-column header ───────────────────────────────────── */
 .bto-header {
+  display: flex;
+  gap: 2rem;
   margin-bottom: 2rem;
+  align-items: flex-start;
 }
-.bto-header h1 {
-  font-size: 1.8rem;
+
+.bto-header-image {
+  width: 360px;
+  flex-shrink: 0;
+  border: 1px solid #e0e0e0;
+  background: #fafafa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.bto-header-image img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.bto-header-info {
+  flex: 1;
+  min-width: 0;
+  padding-top: 0.5rem;
+}
+
+.bto-header-title {
+  font-size: 1.6rem;
   font-weight: 700;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.25rem;
+  line-height: 1.3;
 }
+
 .bto-sku {
   color: #666;
   font-size: 0.9rem;
+  margin: 0 0 1rem;
 }
 
-/* レイアウト */
+.bto-header-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  flex-wrap: wrap;
+}
+
+.bto-header-price-label {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.bto-header-price-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #c00;
+}
+
+.bto-header-price-tax {
+  font-size: 0.85rem;
+  color: #666;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
 .bto-layout {
   display: flex;
-  gap: 2rem;
+  gap: 1.5rem;
   align-items: flex-start;
 }
+
 .bto-main {
   flex: 1;
   min-width: 0;
 }
+
 .bto-sidebar {
-  width: 300px;
+  width: 280px;
   flex-shrink: 0;
   position: sticky;
   top: 1rem;
 }
 
-/* タブ */
-.bto-tabs {
-  display: flex;
-  gap: 0;
-  margin-bottom: 1.5rem;
-  border-bottom: 2px solid #e0e0e0;
-}
-.bto-tab {
-  padding: 0.75rem 1.5rem;
-  border: none;
-  background: none;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #666;
-  cursor: pointer;
-  border-bottom: 3px solid transparent;
-  margin-bottom: -2px;
-  transition: all 0.2s;
-}
-.bto-tab:hover {
-  color: #333;
-}
-.bto-tab.active {
-  color: #000;
-  border-bottom-color: #000;
+/* ── Section groups (hardware / peripheral / service) ────── */
+.bto-section-group {
+  margin-bottom: 2rem;
 }
 
-/* カテゴリ */
+.bto-section-group-label {
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+  background: #444;
+  color: #fff;
+  margin: 0 0 0;
+  border-radius: 0;
+}
+
+/* ── Category rows ───────────────────────────────────────── */
 .bto-categories {
   display: flex;
   flex-direction: column;
-  gap: 0;
-}
-.bto-category {
-  border: 1px solid #e0e0e0;
-  border-bottom: none;
-}
-.bto-category:last-child {
-  border-bottom: 1px solid #e0e0e0;
 }
 
-/* 固定スペック */
+.bto-category {
+  border: 1px solid #ddd;
+  border-top: none;
+}
+
+.bto-category:first-child {
+  border-top: 1px solid #ddd;
+}
+
+/* Fixed spec rows */
 .bto-category-fixed .bto-category-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.75rem 1rem;
+  align-items: baseline;
+  padding: 0.6rem 1rem;
   background: #fff8e1;
-  gap: 1rem;
+  gap: 0;
 }
+
+.bto-category-fixed .bto-category-name {
+  font-weight: 700;
+  font-size: 0.9rem;
+  width: 180px;
+  flex-shrink: 0;
+  color: #333;
+}
+
 .bto-category-fixed .bto-category-value {
   font-size: 0.85rem;
   color: #333;
-  text-align: right;
   flex: 1;
+  line-height: 1.5;
 }
 
-/* 選択可能カテゴリ */
+/* Selectable category toggle rows */
 .bto-category-toggle {
   display: flex;
   align-items: center;
   width: 100%;
-  padding: 0.75rem 1rem;
+  padding: 0.6rem 1rem;
   background: #fff;
   border: none;
   cursor: pointer;
   text-align: left;
-  gap: 0.5rem;
-  transition: background 0.15s;
+  gap: 0;
+  transition: background 0.12s;
+  min-height: 42px;
 }
+
 .bto-category-toggle:hover {
-  background: #f5f5f5;
+  background: #f9f9f9;
 }
+
 .bto-category-name {
-  font-weight: 600;
-  font-size: 0.95rem;
-  white-space: nowrap;
-  min-width: 160px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  width: 180px;
+  flex-shrink: 0;
+  color: #333;
 }
+
 .bto-category-current {
   flex: 1;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   gap: 0.5rem;
   min-width: 0;
 }
+
 .bto-current-label {
   font-size: 0.85rem;
-  color: #555;
+  color: #444;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
 }
+
 .bto-current-price {
   font-size: 0.85rem;
-  color: #c62828;
+  color: #c00;
   font-weight: 600;
   white-space: nowrap;
 }
+
 .bto-chevron {
   font-size: 0.6rem;
   color: #999;
   transition: transform 0.2s;
+  margin-left: 0.5rem;
 }
+
 .bto-chevron.open {
   transform: rotate(180deg);
 }
 
-/* 選択肢一覧 */
+/* ── Option list ─────────────────────────────────────────── */
 .bto-options {
   border-top: 1px solid #eee;
   background: #fafafa;
 }
+
 .bto-option {
   display: flex;
   align-items: flex-start;
-  padding: 0.75rem 1rem 0.75rem 2.5rem;
+  padding: 0.6rem 1rem 0.6rem 2.5rem;
   cursor: pointer;
   border-bottom: 1px solid #f0f0f0;
   transition: background 0.1s;
   gap: 0.5rem;
 }
+
 .bto-option:last-child {
   border-bottom: none;
 }
+
 .bto-option:hover {
-  background: #f0f0f0;
+  background: #f5f5f5;
 }
+
 .bto-option.selected {
   background: #fff8e1;
 }
+
 .bto-option input[type='radio'],
 .bto-option input[type='checkbox'] {
   margin-top: 3px;
-  margin-right: 0.5rem;
   flex-shrink: 0;
+  accent-color: #e65100;
 }
+
 .bto-option-content {
   display: flex;
   justify-content: space-between;
@@ -185,95 +260,202 @@
   gap: 1rem;
   min-width: 0;
 }
+
 .bto-option-name {
-  font-size: 0.9rem;
-  line-height: 1.4;
+  font-size: 0.88rem;
+  line-height: 1.5;
   flex: 1;
+  color: #333;
 }
+
 .bto-option-price {
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 600;
   white-space: nowrap;
   text-align: right;
-  min-width: 100px;
+  min-width: 90px;
+  color: #c00;
 }
+
 .bto-option-price-excl {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 400;
   color: #888;
 }
 
-/* バッジ */
+/* ── Badges ──────────────────────────────────────────────── */
 .bto-badge-recommended {
   display: inline-block;
-  background: #ff6f00;
+  background: #e65100;
   color: #fff;
   font-size: 0.65rem;
   font-weight: 700;
-  padding: 1px 6px;
-  border-radius: 3px;
-  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 2px;
+  margin-left: 5px;
   vertical-align: middle;
 }
+
 .bto-badge-default {
   display: inline-block;
   background: #fdd835;
   color: #333;
   font-size: 0.65rem;
   font-weight: 700;
-  padding: 1px 6px;
-  border-radius: 3px;
-  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 2px;
+  margin-left: 5px;
   vertical-align: middle;
 }
 
-/* 価格ボックス（サイドバー） */
+/* ── Sidebar price box ───────────────────────────────────── */
 .bto-price-box {
-  background: #1a1a1a;
-  color: #fff;
-  border-radius: 12px;
-  padding: 1.5rem;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1.25rem;
   text-align: center;
 }
+
 .bto-price-label {
-  font-size: 0.85rem;
-  color: #aaa;
-  margin-bottom: 0.5rem;
-}
-.bto-price-total {
-  font-size: 2rem;
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-}
-.bto-price-base {
   font-size: 0.8rem;
+  color: #666;
+  margin-bottom: 0.4rem;
+}
+
+.bto-price-total {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: #c00;
+  margin-bottom: 0.35rem;
+  line-height: 1.2;
+}
+
+.bto-price-base {
+  font-size: 0.78rem;
   color: #888;
 }
+
 .bto-price-diff {
-  font-size: 0.8rem;
-  color: #ff8a65;
-  margin-top: 0.25rem;
+  font-size: 0.78rem;
+  color: #e65100;
+  margin-top: 0.2rem;
 }
+
 .bto-cart-button {
   display: block;
   width: 100%;
-  margin-top: 1.5rem;
-  padding: 1rem;
-  background: #ff6f00;
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  background: #e65100;
   color: #fff;
   border: none;
-  border-radius: 8px;
-  font-size: 1.1rem;
+  border-radius: 4px;
+  font-size: 1.05rem;
   font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s;
-}
-.bto-cart-button:hover {
-  background: #e65100;
+  transition: background 0.15s;
 }
 
-/* レスポンシブ */
+.bto-cart-button:hover {
+  background: #bf360c;
+}
+
+.bto-cart-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.bto-cart-error {
+  color: #c00;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+/* ── Out-of-stock dialog ─────────────────────────────────── */
+.bto-oos-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.bto-oos-dialog {
+  background: #fff;
+  border-radius: 6px;
+  max-width: 480px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.bto-oos-dialog-header {
+  padding: 1.25rem 1.25rem 0.75rem;
+  flex-shrink: 0;
+}
+
+.bto-oos-dialog h3 {
+  margin: 0 0 0.5rem;
+  color: #c00;
+  font-size: 1.05rem;
+}
+
+.bto-oos-dialog p {
+  margin: 0;
+  color: #333;
+  font-size: 0.88rem;
+}
+
+.bto-oos-dialog ul {
+  margin: 0;
+  padding: 0.75rem 1.25rem 0.75rem 2.5rem;
+  font-size: 0.82rem;
+  color: #555;
+  line-height: 1.7;
+  overflow-y: auto;
+  flex: 1;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+}
+
+.bto-oos-dialog-footer {
+  padding: 0.9rem 1.25rem;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.bto-oos-close {
+  background: #c00;
+  color: #fff;
+  border: none;
+  padding: 0.45rem 1.25rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.bto-oos-close:hover {
+  background: #900;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .bto-header {
+    flex-direction: column;
+  }
+  .bto-header-image {
+    width: 100%;
+    max-width: 400px;
+  }
+}
+
 @media (max-width: 768px) {
   .bto-layout {
     flex-direction: column;
@@ -286,127 +468,20 @@
     right: 0;
     top: auto;
     z-index: 100;
-    padding: 0;
   }
   .bto-price-box {
     border-radius: 0;
+    border: none;
+    border-top: 1px solid #ddd;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem 1rem;
+    padding: 0.6rem 1rem;
     gap: 1rem;
   }
   .bto-price-label { display: none; }
-  .bto-price-total { font-size: 1.4rem; margin: 0; }
-  .bto-price-base { display: none; }
-  .bto-price-diff { display: none; }
-  .bto-cart-button {
-    margin: 0;
-    width: auto;
-    padding: 0.75rem 1.5rem;
-    font-size: 0.9rem;
-  }
-  .bto-main {
-    padding-bottom: 80px;
-  }
-  .bto-category-name {
-    min-width: 80px;
-    font-size: 0.85rem;
-  }
-}
-/* ============================================================
-   カート追加関連の追加CSS
-   既存の bto.css の末尾に追記してください
-   ============================================================ */
-
-.bto-cart-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-.bto-cart-error {
-  color: #ff5252;
-  font-size: 0.75rem;
-  margin-top: 0.5rem;
-}
-.bto-view-cart {
-  display: block;
-  text-align: center;
-  margin-top: 0.75rem;
-  color: #fff;
-  font-size: 0.9rem;
-  text-decoration: underline;
-}
-.bto-view-cart:hover {
-  color: #ff8a65;
-}
-/* Out-of-stock dialog */
-.bto-oos-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.bto-oos-dialog {
-  background: #fff;
-  border-radius: 8px;
-  max-width: 480px;
-  width: 90%;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  overflow: hidden;
-}
-
-.bto-oos-dialog-header {
-  padding: 1.5rem 1.5rem 0.75rem;
-  flex-shrink: 0;
-}
-
-.bto-oos-dialog h3 {
-  margin: 0 0 0.5rem;
-  color: #e30000;
-  font-size: 1.1rem;
-}
-
-.bto-oos-dialog p {
-  margin: 0;
-  color: #333;
-  font-size: 0.9rem;
-}
-
-.bto-oos-dialog ul {
-  margin: 0;
-  padding: 0.75rem 1.5rem 0.75rem 2.75rem;
-  font-size: 0.82rem;
-  color: #555;
-  line-height: 1.7;
-  overflow-y: auto;
-  flex: 1;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-}
-
-.bto-oos-dialog-footer {
-  padding: 1rem 1.5rem;
-  flex-shrink: 0;
-  text-align: right;
-}
-
-.bto-oos-close {
-  background: #e30000;
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9rem;
-}
-
-.bto-oos-close:hover {
-  background: #b30000;
+  .bto-price-total { font-size: 1.3rem; margin: 0; }
+  .bto-price-base, .bto-price-diff { display: none; }
+  .bto-cart-button { margin: 0; width: auto; padding: 0.65rem 1.25rem; font-size: 0.9rem; }
+  .bto-main { padding-bottom: 72px; }
+  .bto-category-name { width: 100px; font-size: 0.82rem; }
 }


### PR DESCRIPTION
## Summary

This PR wraps up the BTO configurator with a UI redesign, comprehensive developer documentation, and the Shopify app containing the Cart Transform Function.

### BTO configurator UI redesign
- **Product image** in a two-column header (image left, price right) — matching Mouse Computer reference
- **Single scrollable list** replacing tab navigation — all categories visible at once, grouped under ハードウェア / 周辺機器 / ソフト・サービス headings
- **Clean white layout** throughout — white sidebar with red price and orange cart button
- **Category rows** with bold 180px name column + current value + chevron
- **Fixed rows** with warm beige background to distinguish non-selectable specs
- Responsive: stacked on mobile with sticky bottom price/button bar

### Developer documentation (`docs/`)
Two ~4,000-word guides covering the full architecture:
- `how-this-was-built-en.md` — English
- `how-this-was-built-ja.md` — Japanese

Both include ASCII diagrams for: system architecture, data model, OAuth sequence, loader data flow, cart bundle layout, Cart Transform algorithm, end-to-end user flow, and API reference tables.

### bto-calculator Shopify app
Added the Shopify app (previously its own git repo) into the monorepo at `bto-calculator/`:
- Cart Transform Function (Rust/WASM) at `extensions/cart-transformer-bto/`
- Groups cart lines by `_bto_bundle_id` → `linesMerge` → single bundle at checkout
- Forwards `_bto_upgrades` attribute through merge for cart display
- Test fixtures for bundle merge and no-operations cases
- Deploy: `cd bto-calculator && shopify app deploy`

## Test plan
- [ ] BTO configurator page shows product image in header
- [ ] All component sections visible without tabs
- [ ] `docs/how-this-was-built-en.md` renders correctly on GitHub
- [ ] `bto-calculator/` builds: `cd bto-calculator/extensions/cart-transformer-bto && cargo build --target=wasm32-unknown-unknown --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)