### PR TITLE
Improve cart UX: one-bundle policy, edit flow, loading states, Japanese UI

### DIFF
--- a/app/components/CartLineItem.jsx
+++ b/app/components/CartLineItem.jsx
@@ -132,10 +132,10 @@ function CartLineQuantity({line}) {
 
   return (
     <div className="cart-line-quantity">
-      <small>Quantity: {quantity} &nbsp;&nbsp;</small>
+      <small>数量: {quantity} &nbsp;&nbsp;</small>
       <CartLineUpdateButton lines={[{id: lineId, quantity: prevQuantity}]}>
         <button
-          aria-label="Decrease quantity"
+          aria-label="数量を減らす"
           disabled={quantity <= 1 || !!isOptimistic}
           name="decrease-quantity"
           value={prevQuantity}
@@ -146,7 +146,7 @@ function CartLineQuantity({line}) {
       &nbsp;
       <CartLineUpdateButton lines={[{id: lineId, quantity: nextQuantity}]}>
         <button
-          aria-label="Increase quantity"
+          aria-label="数量を増やす"
           name="increase-quantity"
           value={nextQuantity}
           disabled={!!isOptimistic}
@@ -178,7 +178,7 @@ function CartLineRemoveButton({lineIds, disabled}) {
       inputs={{lineIds}}
     >
       <button disabled={disabled} type="submit" className="cart-bto-remove">
-        Remove
+        削除
       </button>
     </CartForm>
   );

--- a/app/components/CartMain.jsx
+++ b/app/components/CartMain.jsx
@@ -1,6 +1,6 @@
 import {useOptimisticCart, CartForm, Image} from '@shopify/hydrogen';
-import {Link} from 'react-router';
-import {useState} from 'react';
+import {Link, useLocation} from 'react-router';
+import {useState, useEffect} from 'react';
 import {useAside} from '~/components/Aside';
 import {CartLineItem} from '~/components/CartLineItem';
 import {CartSummary} from './CartSummary';
@@ -86,7 +86,7 @@ export function CartMain({layout, cart: originalCart}) {
             inputs={{lineIds: cart.lines.nodes.map((l) => l.id)}}
           >
             <button type="submit" className="cart-remove-all">
-              Remove all
+              すべて削除
             </button>
           </CartForm>
         )}
@@ -133,9 +133,21 @@ export function CartMain({layout, cart: originalCart}) {
 
 // Renders a BTO line after the Cart Transform Function has merged it
 function MergedBTOLineItem({line}) {
+  const {close} = useAside();
   const {product, image} = line.merchandise;
   const productName = line.attributes?.find((a) => a.key === '_bto_product')?.value || product.title;
   const upgrades = line.attributes?.find((a) => a.key === '_bto_upgrades')?.value;
+  // _bto_handle may be absent if the Cart Transform Function did not forward it;
+  // fall back to whatever the user last visited via localStorage.
+  const attrHandle = line.attributes?.find((a) => a.key === '_bto_handle')?.value;
+  const [storedBtoPath, setStoredBtoPath] = useState(null);
+  useEffect(() => {
+    if (!attrHandle) {
+      const saved = localStorage.getItem('lastBtoPath');
+      if (saved) setStoredBtoPath(saved);
+    }
+  }, [attrHandle]);
+  const editPath = attrHandle ? `/bto/${attrHandle}` : storedBtoPath;
   const price = line.cost?.totalAmount?.amount;
 
   return (
@@ -150,9 +162,20 @@ function MergedBTOLineItem({line}) {
             {price ? `¥${Number(price).toLocaleString('ja-JP')}` : '—'}
           </p>
           {upgrades && <p className="cart-bto-upgrades">{upgrades}</p>}
-          <CartForm route="/cart" action={CartForm.ACTIONS.LinesRemove} inputs={{lineIds: [line.id]}}>
-            <button type="submit" className="cart-bto-remove">Remove</button>
-          </CartForm>
+          <div className="cart-bto-actions">
+            {editPath && (
+              <Link to={editPath} className="cart-bto-edit" onClick={close}>編集</Link>
+            )}
+            <CartForm route="/cart" action={CartForm.ACTIONS.LinesRemove} inputs={{lineIds: [line.id]}}>
+              {(fetcher) => (
+                <button type="submit" className="cart-bto-remove" disabled={fetcher.state !== 'idle'}>
+                  {fetcher.state !== 'idle' ? (
+                    <span className="cart-loading-spinner" aria-label="削除中" />
+                  ) : '削除'}
+                </button>
+              )}
+            </CartForm>
+          </div>
         </div>
       </div>
     </li>
@@ -160,10 +183,12 @@ function MergedBTOLineItem({line}) {
 }
 
 function BTOBundleItem({base, components, layout}) {
+  const {close} = useAside();
   const [showComponents, setShowComponents] = useState(false);
   const {product, image} = base.merchandise;
   const productName = base.attributes?.find((a) => a.key === '_bto_product')?.value || product.title;
   const upgrades = base.attributes?.find((a) => a.key === '_bto_upgrades')?.value;
+  const handle = base.attributes?.find((a) => a.key === '_bto_handle')?.value;
   const count = components.length;
   const allLineIds = [base.id, ...components.map((c) => c.id)];
 
@@ -181,7 +206,7 @@ function BTOBundleItem({base, components, layout}) {
             className="cart-bto-toggle"
             onClick={() => setShowComponents((v) => !v)}
           >
-            {showComponents ? `Hide ${count} items ↑` : `Show ${count} items ↓`}
+            {showComponents ? `構成を隠す ↑` : `構成を表示 (${count}件) ↓`}
           </button>
           {showComponents && (
             <ul className="cart-bto-components">
@@ -192,13 +217,24 @@ function BTOBundleItem({base, components, layout}) {
               ))}
             </ul>
           )}
-          <CartForm
-            route="/cart"
-            action={CartForm.ACTIONS.LinesRemove}
-            inputs={{lineIds: allLineIds}}
-          >
-            <button type="submit" className="cart-bto-remove">Remove</button>
-          </CartForm>
+          <div className="cart-bto-actions">
+            {handle && (
+              <Link to={`/bto/${handle}`} className="cart-bto-edit" onClick={close}>編集</Link>
+            )}
+            <CartForm
+              route="/cart"
+              action={CartForm.ACTIONS.LinesRemove}
+              inputs={{lineIds: allLineIds}}
+            >
+              {(fetcher) => (
+                <button type="submit" className="cart-bto-remove" disabled={fetcher.state !== 'idle'}>
+                  {fetcher.state !== 'idle' ? (
+                    <span className="cart-loading-spinner" aria-label="削除中" />
+                  ) : '削除'}
+                </button>
+              )}
+            </CartForm>
+          </div>
         </div>
       </div>
     </li>
@@ -213,17 +249,29 @@ function BTOBundleItem({base, components, layout}) {
  */
 function CartEmpty({hidden = false}) {
   const {close} = useAside();
+  const location = useLocation();
+  const [storedBtoPath, setStoredBtoPath] = useState(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('lastBtoPath');
+    if (saved) setStoredBtoPath(saved);
+  }, []);
+
+  // If the cart aside is open while the user is on a BTO page, use that path directly.
+  // Otherwise fall back to whatever was last stored in localStorage.
+  const isBtoPage = location.pathname.startsWith('/bto/');
+  const continuePath = isBtoPage ? location.pathname : storedBtoPath;
+
   return (
     <div hidden={hidden}>
       <br />
-      <p>
-        Looks like you haven&rsquo;t added anything yet, let&rsquo;s get you
-        started!
-      </p>
+      <p>カートにはまだ商品がありません。</p>
       <br />
-      <Link to="/collections" onClick={close} prefetch="viewport">
-        Continue shopping →
-      </Link>
+      {continuePath && (
+        <Link to={continuePath} onClick={close} prefetch="viewport">
+          ショッピングを続ける →
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/components/CartSummary.jsx
+++ b/app/components/CartSummary.jsx
@@ -11,9 +11,9 @@ export function CartSummary({cart, layout}) {
 
   return (
     <div aria-labelledby="cart-summary" className={className}>
-      <h4>Totals</h4>
+      <h4 className="cart-summary-heading">合計</h4>
       <dl className="cart-subtotal">
-        <dt>Subtotal</dt>
+        <dt>小計</dt>
         <dd>
           {cart?.cost?.subtotalAmount?.amount ? (
             <Money data={cart?.cost?.subtotalAmount} />
@@ -36,11 +36,10 @@ function CartCheckoutActions({checkoutUrl}) {
   if (!checkoutUrl) return null;
 
   return (
-    <div>
-      <a href={checkoutUrl} target="_self">
-        <p>Continue to Checkout &rarr;</p>
+    <div className="cart-checkout-actions">
+      <a href={checkoutUrl} target="_self" className="cart-checkout-button">
+        チェックアウトへ進む &rarr;
       </a>
-      <br />
     </div>
   );
 }
@@ -57,38 +56,38 @@ function CartDiscounts({discountCodes}) {
       ?.map(({code}) => code) || [];
 
   return (
-    <div>
-      {/* Have existing discount, display it with a remove option */}
+    <div className="cart-coupon-section">
+      {/* Applied discount codes */}
       <dl hidden={!codes.length}>
         <div>
-          <dt>Discount(s)</dt>
+          <dt>割引コード</dt>
           <UpdateDiscountForm>
             <div className="cart-discount">
               <code>{codes?.join(', ')}</code>
               &nbsp;
-              <button type="submit" aria-label="Remove discount">
-                Remove
+              <button type="submit" aria-label="割引コードを削除">
+                削除
               </button>
             </div>
           </UpdateDiscountForm>
         </div>
       </dl>
 
-      {/* Show an input to apply a discount */}
+      {/* Input to apply a discount */}
       <UpdateDiscountForm discountCodes={codes}>
-        <div>
+        <div className="cart-code-row">
           <label htmlFor="discount-code-input" className="sr-only">
-            Discount code
+            割引コード
           </label>
           <input
             id="discount-code-input"
+            className="cart-code-input"
             type="text"
             name="discountCode"
-            placeholder="Discount code"
+            placeholder="割引コード"
           />
-          &nbsp;
-          <button type="submit" aria-label="Apply discount code">
-            Apply
+          <button type="submit" className="cart-code-apply" aria-label="割引コードを適用">
+            適用
           </button>
         </div>
       </UpdateDiscountForm>
@@ -132,10 +131,10 @@ function CartGiftCard({giftCardCodes}) {
   }, [giftCardAddFetcher.data]);
 
   return (
-    <div>
+    <div className="cart-coupon-section">
       {giftCardCodes && giftCardCodes.length > 0 && (
         <dl>
-          <dt>Applied Gift Card(s)</dt>
+          <dt>適用済みギフトカード</dt>
           {giftCardCodes.map((giftCard) => (
             <RemoveGiftCardForm key={giftCard.id} giftCardId={giftCard.id}>
               <div className="cart-discount">
@@ -143,7 +142,7 @@ function CartGiftCard({giftCardCodes}) {
                 &nbsp;
                 <Money data={giftCard.amountUsed} />
                 &nbsp;
-                <button type="submit">Remove</button>
+                <button type="submit">削除</button>
               </div>
             </RemoveGiftCardForm>
           ))}
@@ -151,16 +150,20 @@ function CartGiftCard({giftCardCodes}) {
       )}
 
       <AddGiftCardForm fetcherKey="gift-card-add">
-        <div>
+        <div className="cart-code-row">
           <input
+            className="cart-code-input"
             type="text"
             name="giftCardCode"
-            placeholder="Gift card code"
+            placeholder="ギフトカードコード"
             ref={giftCardCodeInput}
           />
-          &nbsp;
-          <button type="submit" disabled={giftCardAddFetcher.state !== 'idle'}>
-            Apply
+          <button
+            type="submit"
+            className="cart-code-apply"
+            disabled={giftCardAddFetcher.state !== 'idle'}
+          >
+            適用
           </button>
         </div>
       </AddGiftCardForm>

--- a/app/routes/bto.$handle.jsx
+++ b/app/routes/bto.$handle.jsx
@@ -13,7 +13,7 @@
 
 import {useLoaderData} from 'react-router';
 import {CartForm, Image} from '@shopify/hydrogen';
-import {useState, useMemo, useCallback} from 'react';
+import {useState, useMemo, useCallback, useEffect} from 'react';
 import '../styles/bto.css';
 
 export async function loader({params, context}) {
@@ -71,6 +71,27 @@ export async function loader({params, context}) {
     }
   }
 
+  // Fetch current cart only to support edit-mode restoration of saved selections
+  const cartData = await context.cart.get();
+  const allCartLines = cartData?.lines?.nodes ?? [];
+
+  // Find base line for THIS specific product handle to restore its selections
+  const existingBase = allCartLines.find(
+    (l) =>
+      l.attributes?.find((a) => a.key === '_bto_handle')?.value === metaobject.handle &&
+      l.attributes?.find((a) => a.key === '_bto_role')?.value === 'base',
+  );
+  const savedSelectionsJson =
+    existingBase?.attributes?.find((a) => a.key === '_bto_selections')?.value ?? null;
+  let savedSelections = null;
+  if (savedSelectionsJson) {
+    try {
+      savedSelections = JSON.parse(savedSelectionsJson);
+    } catch {
+      savedSelections = null;
+    }
+  }
+
   return {
     handle: metaobject.handle,
     productName: fields.product_name,
@@ -83,13 +104,15 @@ export async function loader({params, context}) {
     variantId: product?.variants?.nodes?.[0]?.id || null,
     productImage: product?.featuredImage || null,
     availabilityMap,
+    savedSelections,
+    isEditMode: Boolean(savedSelections),
   };
 }
 
 
 export default function BTOConfigurator() {
   const data = useLoaderData();
-  const {productName, basePrice, hardwareConfig, peripheralConfig, serviceConfig, variantId, productImage, availabilityMap} = data;
+  const {handle, productName, basePrice, hardwareConfig, peripheralConfig, serviceConfig, variantId, productImage, availabilityMap, savedSelections, isEditMode} = data;
   const [outOfStockDialog, setOutOfStockDialog] = useState(null);
   const allSections = [
     ...hardwareConfig.sections,
@@ -107,8 +130,13 @@ export default function BTOConfigurator() {
     }
   }
 
-  const [selections, setSelections] = useState(initialSelections);
+  const [selections, setSelections] = useState(savedSelections ?? initialSelections);
   const [activeTab, setActiveTab] = useState('hardware');
+
+  // Persist this product's path so CartEmpty can link back here
+  useEffect(() => {
+    localStorage.setItem('lastBtoPath', `/bto/${handle}`);
+  }, [handle]);
 
   const totalPrice = useMemo(() => {
     let total = basePrice;
@@ -154,6 +182,8 @@ export default function BTOConfigurator() {
       {key: '_bto_bundle_id', value: bundleId},
       {key: '_bto_role', value: 'base'},
       {key: '_bto_product', value: productName},
+      {key: '_bto_handle', value: handle},
+      {key: '_bto_selections', value: JSON.stringify(selections)},
       ...(upgrades.length > 0 ? [{key: '_bto_upgrades', value: upgrades.join(' / ')}] : []),
     ];
 
@@ -326,20 +356,29 @@ export default function BTOConfigurator() {
                 inputs={{lines: buildCartLines()}}
               >
                 {(fetcher) => (
-                  <button
-                    className="bto-cart-button"
-                    type="submit"
-                    disabled={fetcher.state !== 'idle'}
-                    onClick={(e) => {
-                      const oos = checkInventory();
-                      if (oos.length > 0) {
-                        e.preventDefault();
-                        setOutOfStockDialog(oos);
-                      }
-                    }}
-                  >
-                    {fetcher.state !== 'idle' ? '追加中...' : 'カートに追加'}
-                  </button>
+                  <>
+                    <button
+                      className="bto-cart-button"
+                      type="submit"
+                      disabled={fetcher.state !== 'idle'}
+                      onClick={(e) => {
+                        const oos = checkInventory();
+                        if (oos.length > 0) {
+                          e.preventDefault();
+                          setOutOfStockDialog(oos);
+                        }
+                      }}
+                    >
+                      {fetcher.state !== 'idle'
+                        ? '反映中...'
+                        : isEditMode
+                        ? 'カートに反映（上書き）'
+                        : 'カートに反映'}
+                    </button>
+                    {isEditMode && (
+                      <p className="bto-edit-notice">※ 現在のカスタマイズを上書きします</p>
+                    )}
+                  </>
                 )}
               </CartForm>
             ) : (

--- a/app/routes/cart.jsx
+++ b/app/routes/cart.jsx
@@ -1,4 +1,5 @@
-import {useLoaderData, data} from 'react-router';
+import {useLoaderData, useNavigation, useRevalidator, data} from 'react-router';
+import {useEffect} from 'react';
 import {CartForm} from '@shopify/hydrogen';
 import {CartMain} from '~/components/CartMain';
 
@@ -32,21 +33,35 @@ export async function action({request, context}) {
   let result;
 
   switch (action) {
-    case CartForm.ACTIONS.LinesAdd:
-      console.log('[BTO debug] LinesAdd received', inputs.lines?.length, 'lines');
-      console.log('[BTO debug] lines:', JSON.stringify(inputs.lines?.map(l => ({
-        merchandiseId: l.merchandiseId,
-        role: l.attributes?.find(a => a.key === '_bto_role')?.value,
-        bundleId: l.attributes?.find(a => a.key === '_bto_bundle_id')?.value?.slice(0, 8),
-      }))));
+    case CartForm.ACTIONS.LinesAdd: {
+      // One-BTO-bundle-at-a-time: if any incoming line is a BTO line, remove ALL existing
+      // BTO lines from the live cart first (server-authoritative).
+      //
+      // Two cases to detect:
+      //   • Pre-transform  → regular CartLine with _bto_bundle_id attribute
+      //   • Post-transform → ComponentizableCartLine (Cart Transform Function already ran);
+      //     the parent node has lineComponents but _bto_bundle_id lives inside them, not on
+      //     the parent. Detecting lineComponents != null covers this case.
+      const isBtoAdd = inputs.lines?.some((l) =>
+        l.attributes?.some((a) => a.key === '_bto_bundle_id'),
+      );
+      if (isBtoAdd) {
+        const currentCart = await cart.get();
+        const btoLineIds =
+          currentCart?.lines?.nodes
+            ?.filter(
+              (l) =>
+                l.attributes?.some((a) => a.key === '_bto_bundle_id') ||
+                l.lineComponents != null,
+            )
+            ?.map((l) => l.id) ?? [];
+        if (btoLineIds.length > 0) {
+          await cart.removeLines(btoLineIds);
+        }
+      }
       result = await cart.addLines(inputs.lines);
-      console.log('[BTO debug] result keys:', Object.keys(result || {}));
-      console.log('[BTO debug] userErrors:', JSON.stringify(result?.userErrors));
-      console.log('[BTO debug] errors:', JSON.stringify(result?.errors));
-      console.log('[BTO debug] cart totalQuantity:', result?.cart?.totalQuantity);
-      if (result?.userErrors?.length) console.log('[BTO debug] userErrors detail:', JSON.stringify(result.userErrors));
-      if (result?.warnings?.length) console.log('[BTO debug] warnings:', JSON.stringify(result.warnings));
       break;
+    }
     case CartForm.ACTIONS.LinesUpdate:
       result = await cart.updateLines(inputs.lines);
       break;
@@ -122,10 +137,28 @@ export async function loader({context}) {
 export default function Cart() {
   /** @type {LoaderReturnData} */
   const cart = useLoaderData();
+  const navigation = useNavigation();
+  const revalidator = useRevalidator();
+
+  // Re-fetch cart when user returns to this tab (e.g. after visiting Shopify checkout)
+  useEffect(() => {
+    const handleFocus = () => {
+      if (revalidator.state === 'idle') revalidator.revalidate();
+    };
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, [revalidator]);
+
+  const isLoading = navigation.state !== 'idle' || revalidator.state !== 'idle';
 
   return (
-    <div className="cart">
-      <h1>Cart</h1>
+    <div className="cart-page">
+      <h1 className="cart-page-heading">カート</h1>
+      {isLoading && (
+        <div className="cart-loading-overlay">
+          <span className="cart-loading-spinner" aria-label="読み込み中" />
+        </div>
+      )}
       <CartMain layout="page" cart={cart} />
     </div>
   );

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -262,34 +262,54 @@ button.reset:hover:not(:has(> *)) {
 }
 
 .cart-line {
-  padding: 0.75rem 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid #f0f0f0;
 }
+.cart-line:last-child { border-bottom: none; }
 
 .cart-line-inner {
   display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
 }
 
 .cart-line img {
-  height: 100%;
-  display: block;
-  margin-right: 0.75rem;
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #e8e8e8;
+  flex-shrink: 0;
 }
 
 .cart-summary-page {
   position: relative;
+  border-top: 2px solid #e5e5e5;
+  padding-top: 1.25rem;
+  margin-top: 0.5rem;
 }
 
 .cart-summary-aside {
-  background: white;
-  border-top: 1px solid var(--color-dark);
+  background: #fff;
+  border-top: 2px solid #e5e5e5;
   bottom: 0;
-  padding-top: 0.75rem;
+  padding: 1rem 1.25rem 1.25rem;
   position: absolute;
   width: calc(var(--aside-width) - 40px);
 }
 
+.cart-summary-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: #111;
+}
+
 .cart-line-quantity {
   display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.4rem;
 }
 
 /* Line item attributes (BTO config, custom options, etc.) */
@@ -368,10 +388,68 @@ button.reset:hover:not(:has(> *)) {
   margin-top: 0.25rem;
 }
 
+/* Subtotal row */
 .cart-subtotal {
-  align-items: center;
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #111;
 }
+
+/* Discount / gift card input rows */
+.cart-coupon-section {
+  margin-bottom: 0.75rem;
+}
+
+.cart-code-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+}
+
+.cart-code-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  outline: none;
+}
+.cart-code-input:focus { border-color: #555; }
+
+.cart-code-apply {
+  padding: 0.5rem 1rem;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.cart-code-apply:hover { background: #e8e8e8; }
+
+/* Checkout button */
+.cart-checkout-actions {
+  margin-top: 1rem;
+}
+
+.cart-checkout-button {
+  display: block;
+  width: 100%;
+  padding: 0.9rem 1.5rem;
+  background: #e65100;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+.cart-checkout-button:hover { background: #bf360c; }
 /*
 * --------------------------------------------------
 * components/Search
@@ -866,21 +944,24 @@ button.reset:hover:not(:has(> *)) {
 
 .cart-remove-all {
   background: none;
-  border: 1px solid #ccc;
-  color: #999;
+  border: none;
+  color: #aaa;
   font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
+  padding: 0;
   cursor: pointer;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
-.cart-remove-all:hover { border-color: #e30000; color: #e30000; }
+.cart-remove-all:hover { color: #e30000; }
 
 
 /* BTO bundle in cart */
 .cart-bto-bundle {
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid #f0f0f0;
   padding: 1rem 0;
 }
+.cart-bto-bundle:last-child { border-bottom: none; }
 
 .cart-bto-price {
   font-size: 0.95rem;
@@ -932,4 +1013,71 @@ button.reset:hover:not(:has(> *)) {
   color: #555;
   margin: 0 0 0.4rem;
   line-height: 1.5;
+}
+
+.cart-bto-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.4rem;
+}
+
+.cart-bto-edit {
+  font-size: 0.82rem;
+  color: #0066cc;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.cart-bto-edit:hover { color: #004499; }
+
+/* Cart loading overlay (shown during navigation or revalidation) */
+.cart-loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+/* Spinning loader used in cart loading overlay and remove buttons */
+.cart-loading-spinner {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: cart-spin 0.6s linear infinite;
+}
+
+.cart-bto-remove .cart-loading-spinner {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+
+/* Cart page (/cart) layout */
+.cart-page {
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 0 1.25rem 3rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic', Meiryo, sans-serif;
+}
+
+.cart-page-heading {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #e5e5e5;
+  color: #111;
+}
+
+@keyframes cart-spin {
+  to { transform: rotate(360deg); }
 }

--- a/app/styles/bto.css
+++ b/app/styles/bto.css
@@ -367,6 +367,13 @@
   cursor: not-allowed;
 }
 
+.bto-edit-notice {
+  font-size: 0.78rem;
+  color: #e67e22;
+  margin-top: 0.4rem;
+  text-align: center;
+}
+
 .bto-cart-error {
   color: #c00;
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary

- **One-bundle-at-a-time enforcement**: The cart action now fetches the live cart before every BTO add and removes existing bundles server-side — handling both pre-transform lines (`_bto_bundle_id`) and post-transform `ComponentizableCartLine` nodes produced by the Cart Transform Function
- **Edit flow**: `_bto_handle` and `_bto_selections` are stored as cart line attributes on the base line; the BTO loader reads these on page load to restore previous selections. The configurator button switches to 「カートに反映（上書き）」when editing. 「編集」link appears next to 「削除」in cart items, with a `localStorage` fallback for merged lines where the Cart Transform does not forward `_bto_handle`
- **Loading states**: Remove buttons show a spinner via `fetcher.state`; a full-page overlay appears during navigation/revalidation; `window.focus` triggers `useRevalidator` so the cart refreshes after returning from Shopify checkout
- **Japanese UI + visual polish**: All cart text translated (CartMain, CartLineItem, CartSummary); orange checkout button; styled discount/gift-card input rows; card-style line items; 「ショッピングを続ける」resolves dynamically via `useLocation` + `localStorage`

## Test plan

- [ ] Add BTO bundle → add again with different config → only one bundle in cart
- [ ] Click 「編集」in cart → configurator opens with previous selections pre-populated → click 「カートに反映」→ cart updated with new config
- [ ] Click 「削除」→ spinner shows, button disabled until complete
- [ ] Navigate to Shopify checkout then return → cart data refreshes automatically
- [ ] Empty cart shows 「ショッピングを続ける」linking back to the correct BTO product page
- [ ] All cart text displays in Japanese with no English strings remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)